### PR TITLE
Remove torch.compile from INR ray helpers for Windows compatibility

### DIFF
--- a/src/quantem/tomography/dataset_models.py
+++ b/src/quantem/tomography/dataset_models.py
@@ -536,7 +536,6 @@ class TomographyINRDataset(TomographyDatasetConstraints, Dataset):
         return all_coords
 
     @staticmethod
-    @torch.compile(mode="reduce-overhead")
     def create_batch_rays(
         pixel_i: torch.Tensor, pixel_j: torch.Tensor, N: int, num_samples_per_ray: int
     ) -> torch.Tensor:
@@ -599,7 +598,6 @@ class TomographyINRDataset(TomographyDatasetConstraints, Dataset):
         return transformed_rays
 
     @staticmethod
-    @torch.compile(mode="reduce-overhead")
     def integrate_rays(
         rays: torch.Tensor, num_samples_per_ray: int, target_values_len: int
     ) -> torch.Tensor:


### PR DESCRIPTION
Hot-fix, take out `@torch.compile` flags in tests.